### PR TITLE
Made ``contrib.common.middleware`` Django 1.10 compatible.

### DIFF
--- a/djangae/contrib/common/middleware.py
+++ b/djangae/contrib/common/middleware.py
@@ -1,7 +1,12 @@
 from djangae.contrib.common import _thread_locals
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
-class RequestStorageMiddleware:
+
+class RequestStorageMiddleware(MiddlewareMixin):
     """ Middleware which allows us to get hold of the request object in places where Django doesn't give it to us, e.g. in model save methods.
         Use get_request() to access the request object.
     """


### PR DESCRIPTION
Fixes issue with ``contrib.common.RequestStorageMiddleware`` not being compatible with Django 1.10 when using the new ``MIDDLEWARE`` setting.